### PR TITLE
Hide Loading dialog after successfull request.

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -71,5 +71,6 @@ export const buildSuccess = (
     commit(types.SUCCESS, msg)
   }
   commit(types.ERROR, null)
+  commit(types.SHOW_LOADING, false)
   resolve(resolveParam)
 }


### PR DESCRIPTION
Progress bar was not disappearing after successful request. 
For example just hit the 'Save' on My Profile page.